### PR TITLE
Removed timeInterval on DateTimePicker and refactored formatDate

### DIFF
--- a/components/dateTimePicker.js
+++ b/components/dateTimePicker.js
@@ -9,7 +9,6 @@ export const DateTimePicker = ({ selected, onChange }) => {
       onChange={onChange}
       showTimeSelect
       timeFormat="HH:mm"
-      timeIntervals={24}
       timeCaption="Time"
       dateFormat="yyyy-MM-dd h:mm aa"
     />

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -60,10 +60,10 @@ export const formatDate = (date, isGMT = false) => {
   }
   // convert to RFC3339 then to yyyy-mm-dd hh:mm
   return new Date(date - timeZoneOffset)
-  .toISOString()
-  .slice(0, -1)
-  .slice(0, -7)
-  .replace('T', ' ');
+    .toISOString()
+    .slice(0, -1)
+    .slice(0, -7)
+    .replace('T', ' ');
 };
 
 export const getDocument = async (hackathon, collection) => {

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -45,25 +45,21 @@ const InternalWebsitesCollection = 'InternalWebsites';
 const CMSCollection = 'CMS';
 const LivesiteCollection = 'Livesite';
 
-export const formatDate = (date, preProcessed = false) => {
+// formats timestamp to yyyy-mm-dd hh:mm of type string
+export const formatDate = (date, isGMT = false) => {
   if (!date) {
-    return 'invalid date';
+    date = getTimestamp().seconds;
   }
   const timeZoneOffset = new Date().getTimezoneOffset() * 60000;
-  if (!preProcessed) {
+  if (!isGMT) {
     date = new Date(date * 1000);
-  } else {
-    return new Date(date - timeZoneOffset)
+  }
+  // convert to RFC3339 then to yyyy-mm-dd hh:mm
+  return new Date(date - timeZoneOffset)
       .toISOString()
       .slice(0, -1)
       .slice(0, -7)
       .replace('T', ' ');
-  }
-  return new Date(date - timeZoneOffset)
-    .toISOString()
-    .slice(0, -1)
-    .slice(0, -7)
-    .replace('T', ' ');
 };
 
 export const getTimestamp = () => {

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -59,9 +59,12 @@ export const formatDate = (date, isGMT = false) => {
     date = new Date(date * 1000);
   }
   // convert to RFC3339 then to yyyy-mm-dd hh:mm
-  return new Date(date - timeZoneOffset).toISOString().slice(0, -1).slice(0, -7).replace('T', ' ');
+  return new Date(date - timeZoneOffset)
+  .toISOString()
+  .slice(0, -1)
+  .slice(0, -7)
+  .replace('T', ' ');
 };
-
 
 export const getDocument = async (hackathon, collection) => {
   if (collection === hackathon) {

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -45,6 +45,10 @@ const InternalWebsitesCollection = 'InternalWebsites';
 const CMSCollection = 'CMS';
 const LivesiteCollection = 'Livesite';
 
+export const getTimestamp = () => {
+  return firebase.firestore.Timestamp.now();
+};
+
 // formats timestamp to yyyy-mm-dd hh:mm of type string
 export const formatDate = (date, isGMT = false) => {
   if (!date) {
@@ -55,16 +59,9 @@ export const formatDate = (date, isGMT = false) => {
     date = new Date(date * 1000);
   }
   // convert to RFC3339 then to yyyy-mm-dd hh:mm
-  return new Date(date - timeZoneOffset)
-      .toISOString()
-      .slice(0, -1)
-      .slice(0, -7)
-      .replace('T', ' ');
+  return new Date(date - timeZoneOffset).toISOString().slice(0, -1).slice(0, -7).replace('T', ' ');
 };
 
-export const getTimestamp = () => {
-  return firebase.firestore.Timestamp.now();
-};
 
 export const getDocument = async (hackathon, collection) => {
   if (collection === hackathon) {


### PR DESCRIPTION
removed `timeInterval={24}` (whoops @ianmah my bad)
refactored `formatDate` to set date as current date when an invalid date format is encountered - previously it was set to return 'invalid date' but it caused the whole events page to crash when one tried to edit the event