### PR TITLE
BuildConfig page

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -31,7 +31,7 @@ export const HACKATHON_NAVBAR = {
   events: 'Events',
   spocos: 'Sponsors',
   FeatureFlags: 'Feature Flags',
-  BuildConfig: 'BuildConfig',
+  BuildConfig: 'Build Config',
 };
 export const LIVESITE_NAVBAR = {
   announcements: 'Announcements',

--- a/constants.js
+++ b/constants.js
@@ -31,6 +31,7 @@ export const HACKATHON_NAVBAR = {
   events: 'Events',
   spocos: 'Sponsors',
   FeatureFlags: 'Feature Flags',
+  BuildConfig: 'BuildConfig',
 };
 export const LIVESITE_NAVBAR = {
   announcements: 'Announcements',

--- a/pages/[id]/BuildConfig.js
+++ b/pages/[id]/BuildConfig.js
@@ -2,18 +2,15 @@ import { useState } from 'react';
 import Page from '../../components/page';
 import Card, {
     CardHeader,
-    CardButtonContainer,
     CardTitle,
     CardContent,
   } from '../../components/card';
 import { HACKATHON_NAVBAR } from '../../constants';
 import {
     db,
-    getDocument,
     getHackathonPaths,
     getHackathons,
   } from '../../utility/firebase';
-
   
 export default function BuildConfig({id, hackathons}) {
     const [buildConfig, setBuildConfig] = useState({});
@@ -21,28 +18,58 @@ export default function BuildConfig({id, hackathons}) {
     db.collection('Hackathons').doc(id).onSnapshot(doc => {
         setBuildConfig(doc.data().BuildConfig)
     })  
-    console.log(buildConfig.globalStyling)    
+
     return(
         <Page
         currentPath={id}
         hackathons={hackathons}
         navbarItems={HACKATHON_NAVBAR}
-        >
-            <Card>
-                <CardHeader>
-                    <CardTitle>componentStyling for {id}</CardTitle>
-                    <CardContent>{JSON.stringify(buildConfig.componentStyling)}</CardContent>
-                </CardHeader>
-            </Card>
+        >     
+            {buildConfig === null || buildConfig === undefined ? 
+                <Card>
+                    <CardHeader>
+                        <CardTitle>
+                            No BuildConfig for {id}
+                        </CardTitle>
+                    </CardHeader>                    
+                </Card>
+                :
+                [buildConfig.componentStyling === null || buildConfig.componentStyling === undefined ?
+                <Card>
+                    <CardHeader>
+                        <CardTitle>
+                            No componentStyling for {id}
+                        </CardTitle>
+                    </CardHeader>
+                </Card>
+                :
+                Object.entries(buildConfig.componentStyling).map(([key, val]) => 
+                <Card>
+                    <CardHeader>
+                        <CardTitle>{key}</CardTitle>
+                    </CardHeader>
+                    <CardContent><pre>{JSON.stringify(val, null, 2)}</pre></CardContent>
+                </Card>
+                ),
 
-            <Card>
-                <CardHeader>
-                    <CardTitle>globalStyling for {id}</CardTitle>
-                    <CardContent>{JSON.stringify(buildConfig.globalStyling)}</CardContent>
-                </CardHeader>
-            </Card>
-            
-
+                buildConfig.globalStyling === null || buildConfig.componentStyling === undefined ? 
+                <Card>
+                    <CardHeader>
+                        <CardTitle>
+                            No globalStyling for {id}
+                        </CardTitle>
+                    </CardHeader>
+                </Card>
+                :
+                <Card>
+                    <CardHeader>
+                        <CardTitle>globalStyling</CardTitle>                    
+                    </CardHeader>
+                    <CardContent><pre>{JSON.stringify(buildConfig.globalStyling, null, 2)}</pre></CardContent>
+                </Card>
+                ]
+                
+            }
         </Page>        
     );
 }

--- a/pages/[id]/BuildConfig.js
+++ b/pages/[id]/BuildConfig.js
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import Page from '../../components/page';
+import Card, {
+    CardHeader,
+    CardButtonContainer,
+    CardTitle,
+    CardContent,
+  } from '../../components/card';
+import { HACKATHON_NAVBAR } from '../../constants';
+import {
+    db,
+    getDocument,
+    getHackathonPaths,
+    getHackathons,
+  } from '../../utility/firebase';
+
+  
+export default function BuildConfig({id, hackathons}) {
+    const [buildConfig, setBuildConfig] = useState({});
+
+    db.collection('Hackathons').doc(id).onSnapshot(doc => {
+        setBuildConfig(doc.data().BuildConfig)
+    })  
+    console.log(buildConfig.globalStyling)    
+    return(
+        <Page
+        currentPath={id}
+        hackathons={hackathons}
+        navbarItems={HACKATHON_NAVBAR}
+        >
+            <Card>
+                <CardHeader>
+                    <CardTitle>componentStyling for {id}</CardTitle>
+                    <CardContent>{JSON.stringify(buildConfig.componentStyling)}</CardContent>
+                </CardHeader>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>globalStyling for {id}</CardTitle>
+                    <CardContent>{JSON.stringify(buildConfig.globalStyling)}</CardContent>
+                </CardHeader>
+            </Card>
+            
+
+        </Page>        
+    );
+}
+
+export const getStaticPaths = async () => {
+    return getHackathonPaths();
+  };
+  
+export const getStaticProps = async ({ params }) => {
+    const hackathons = await getHackathons();
+    return {
+        props: {
+        hackathons,
+        id: params.id,
+        },
+    };
+};

--- a/pages/[id]/BuildConfig.js
+++ b/pages/[id]/BuildConfig.js
@@ -1,89 +1,89 @@
 import { useState } from 'react';
 import Page from '../../components/page';
 import Card, {
-    CardHeader,
-    CardTitle,
-    CardContent,
-  } from '../../components/card';
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from '../../components/card';
 import { HACKATHON_NAVBAR } from '../../constants';
-import {
-    db,
-    getHackathonPaths,
-    getHackathons,
-  } from '../../utility/firebase';
-  
-export default function BuildConfig({id, hackathons}) {
-    const [buildConfig, setBuildConfig] = useState({});
+import { db, getHackathonPaths, getHackathons } from '../../utility/firebase';
 
-    db.collection('Hackathons').doc(id).onSnapshot(doc => {
-        setBuildConfig(doc.data().BuildConfig)
-    })  
+export default function BuildConfig({ id, hackathons }) {
+  const [buildConfig, setBuildConfig] = useState({});
 
-    return(
-        <Page
-        currentPath={id}
-        hackathons={hackathons}
-        navbarItems={HACKATHON_NAVBAR}
-        >     
-            {buildConfig === null || buildConfig === undefined ? 
-                <Card>
-                    <CardHeader>
-                        <CardTitle>
-                            No BuildConfig for {id}
-                        </CardTitle>
-                    </CardHeader>                    
-                </Card>
-                :
-                [buildConfig.componentStyling === null || buildConfig.componentStyling === undefined ?
-                <Card>
-                    <CardHeader>
-                        <CardTitle>
-                            No componentStyling for {id}
-                        </CardTitle>
-                    </CardHeader>
-                </Card>
-                :
-                Object.entries(buildConfig.componentStyling).map(([key, val]) => 
-                <Card>
-                    <CardHeader>
-                        <CardTitle>{key}</CardTitle>
-                    </CardHeader>
-                    <CardContent><pre>{JSON.stringify(val, null, 2)}</pre></CardContent>
-                </Card>
-                ),
-
-                buildConfig.globalStyling === null || buildConfig.componentStyling === undefined ? 
-                <Card>
-                    <CardHeader>
-                        <CardTitle>
-                            No globalStyling for {id}
-                        </CardTitle>
-                    </CardHeader>
-                </Card>
-                :
-                <Card>
-                    <CardHeader>
-                        <CardTitle>globalStyling</CardTitle>                    
-                    </CardHeader>
-                    <CardContent><pre>{JSON.stringify(buildConfig.globalStyling, null, 2)}</pre></CardContent>
-                </Card>
-                ]
-                
-            }
-        </Page>        
+  const EmptyConfigComponent = ({ config }) => {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            No {config} for {id}
+          </CardTitle>
+        </CardHeader>
+      </Card>
     );
+  };
+
+  const ViewConfigComponent = ({ title, content }) => {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <pre>{JSON.stringify(content, null, 2)}</pre>
+        </CardContent>
+      </Card>
+    );
+  };
+
+  db.collection('Hackathons')
+    .doc(id)
+    .onSnapshot((doc) => {
+      setBuildConfig(doc.data().BuildConfig);
+    });
+
+  return (
+    <Page
+      currentPath={id}
+      hackathons={hackathons}
+      navbarItems={HACKATHON_NAVBAR}
+    >
+      {!buildConfig ? (
+        <EmptyConfigComponent config="Build Config" />
+      ) : (
+        [
+          !buildConfig.componentStyling ? (
+            <EmptyConfigComponent config="componentStyling" />
+          ) : (
+            Object.entries(buildConfig.componentStyling).map(([key, val]) => (
+              <ViewConfigComponent title={key} content={val} />
+            ))
+          ),
+
+          !buildConfig.globalStyling ? (
+            <EmptyConfigComponent config="globalStyling" />
+          ) : (
+            <ViewConfigComponent
+              title="globalStyling"
+              content={buildConfig.globalStyling}
+            />
+          ),
+        ]
+      )}
+    </Page>
+  );
 }
 
 export const getStaticPaths = async () => {
-    return getHackathonPaths();
-  };
-  
+  return getHackathonPaths();
+};
+
 export const getStaticProps = async ({ params }) => {
-    const hackathons = await getHackathons();
-    return {
-        props: {
-        hackathons,
-        id: params.id,
-        },
-    };
+  const hackathons = await getHackathons();
+  return {
+    props: {
+      hackathons,
+      id: params.id,
+    },
+  };
 };


### PR DESCRIPTION
resolves https://github.com/nwplus/monorepo/issues/34

added tab/page for each hackathon's build configs to view each component and global styling from firebase. lemme know if this is what yall had in mind and any thoughts!

![image](https://user-images.githubusercontent.com/37602670/106203824-d902c180-6170-11eb-9003-765018502851.png)

no build config:
![image](https://user-images.githubusercontent.com/37602670/106203895-f0da4580-6170-11eb-85c6-52fc0ff73a85.png)
